### PR TITLE
Version warning, packaging updates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE
-include README.md
+include LICENSE README.md
 include odmltools/info.json
+recursive-include test/resources *

--- a/odmltools/__init__.py
+++ b/odmltools/__init__.py
@@ -1,5 +1,8 @@
+import warnings
+
 from sys import version_info
 
 if version_info.major < 3 or version_info.major == 3 and version_info.minor < 6:
-    print("WARNING: The odMLtools package is not tested with your Python version. "
-          "Please consider upgrading to the latest Python distribution.")
+    msg = "The '%s' package is not tested with your Python version. " % __name__
+    msg += "Please consider upgrading to the latest Python distribution."
+    warnings.warn(msg)

--- a/odmltools/info.json
+++ b/odmltools/info.json
@@ -7,7 +7,6 @@
   "CLASSIFIERS": [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
This PR
- changes the untested python version print into a proper warning.
- updates the MANIFEST to include test/resources.
- removes the Python 3.5 classifier, since this version is not in the test matrix.
