### PR TITLE
Minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+Used to document all changes from previous releases and collect changes 
+until the next release.
+
+# Latest changes
+
+## Minor updates
+- The package version number is now available from the info file as `VERSION` and `__version__`.
+- The packages `__init__` file checks if the users Python version is supported by this release and prints a warning otherwise. The python version import is renamed from `version_info` to `python_version` to give context to the user when they are importing functions from the main package.
+
+# Version 1.0.0
+
+## Initial Package setup
+- Classifiers, copyright, etc are found in `odmltools/info.json` and available via `odmltools/info.py`.
+- CI support with Travis and Appveyor have been set up.
+- The packages `__init__` file checks if the users Python version is supported by this release and prints a warning otherwise.
+
+## Import datacite script
+- the odmltools.importers package contains a conversion tool from a DataCite XML file (kernel version 4) to odML.
+- this importer handles the latest datacite namespace (http://datacite.org/schema/kernel-4) by default. Further namespaces can be added via the command line to also ensure conversion of previous DataCite version files.
+- on install a command line convenience script `odmlimportdatacite` is set up for this conversion.
+- Basic conversion tests with a full DataCite XML file has been added.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include LICENSE README.md
+include LICENSE README.md CHANGELOG.md
 include odmltools/info.json
 recursive-include test/resources *

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Travis build](https://travis-ci.org/G-Node/odmltools.svg?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/oo5lxr6h4pfc9ly7/branch/master?svg=true)](https://ci.appveyor.com/project/G-Node/odmltools/branch/master)
 ![Test coverage](https://coveralls.io/repos/github/G-Node/odmltools/badge.svg?branch=master)
+[![PyPI version](https://img.shields.io/pypi/v/odmltools.svg)](https://pypi.org/project/odmltools/)
 
 # odmltools
 
@@ -20,7 +21,15 @@ detailed usage descriptions by adding the `help` flag to the command.
 
     odmlimportdatacite -h
 
-# Building from source
+# Installation
+
+## pip installation
+
+The easiest way to install the latest release is via the [odmltools PyPI package](https://pypi.org/project/odmltools/https://pypi.org/project/odmltools/):
+
+    pip install odmltools
+
+## Building from source
 
 To download the odmltools library please either use git and clone
 the repository from GitHub:

--- a/odmltools/__init__.py
+++ b/odmltools/__init__.py
@@ -2,7 +2,11 @@ import warnings
 
 from sys import version_info as python_version
 
+from .info import VERSION
+
 if python_version.major < 3 or python_version.major == 3 and python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__
     msg += "Please consider upgrading to the latest Python distribution."
     warnings.warn(msg)
+
+__version__ = VERSION

--- a/odmltools/__init__.py
+++ b/odmltools/__init__.py
@@ -1,10 +1,10 @@
 import warnings
 
-from sys import version_info as python_version
+from sys import version_info as _python_version
 
 from .info import VERSION
 
-if python_version.major < 3 or python_version.major == 3 and python_version.minor < 6:
+if _python_version.major < 3 or _python_version.major == 3 and _python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__
     msg += "Please consider upgrading to the latest Python distribution."
     warnings.warn(msg)

--- a/odmltools/__init__.py
+++ b/odmltools/__init__.py
@@ -1,8 +1,8 @@
 import warnings
 
-from sys import version_info
+from sys import version_info as python_version
 
-if version_info.major < 3 or version_info.major == 3 and version_info.minor < 6:
+if python_version.major < 3 or python_version.major == 3 and python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__
     msg += "Please consider upgrading to the latest Python distribution."
     warnings.warn(msg)


### PR DESCRIPTION
This PR introduces minor updates
- the packages `__init__` checks the users python version using `sys.version_info` and provides a warning for outdated python version. Since `version_info` is available on package import, it is now available as `python_version` to avoid confusion on the users side.
- the packages version number is now available as `VERSION` and `__version__`.
- a CHANGELOG has been added.
- now that a PyPI package is available, the readme provides a badge to display the latest PyPI release and a link to the PyPI release page.
